### PR TITLE
task: remove `jupyter-llm` image

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -28,11 +28,11 @@ function "check_suffix" {
 # ----------------------------------------------------------------------------------------------------------------------
 
 group "prod" {
-  targets = ["jupyter-llm", "beaker-kernel"]
+  targets = ["beaker-kernel"]
 }
 
 group "default" {
-  targets = ["jupyter-llm-base", "beaker-kernel-base"]
+  targets = ["beaker-kernel-base"]
 }
 
 # ----------------------------------------------------------------------------------------------------------------------
@@ -41,20 +41,10 @@ target "_platforms" {
   platforms = ["linux/amd64"]
 }
 
-target "jupyter-llm-base" {
-	context = "."
-	tags = tag("jupyter-llm", "", "")
-	dockerfile = "Dockerfile"
-}
-
 target "beaker-kernel-base" {
 	context = "."
 	tags = tag("beaker-kernel", "", "")
 	dockerfile = "Dockerfile"
-}
-
-target "jupyter-llm" {
-  inherits = ["_platforms", "jupyter-llm-base"]
 }
 
 target "beaker-kernel" {


### PR DESCRIPTION
Now that we do not need two identical images.