### PR TITLE
Minor fix to install.jl

### DIFF
--- a/environments/julia/install.jl
+++ b/environments/julia/install.jl
@@ -36,7 +36,7 @@ end
 
 import Pkg
 Pkg.activate(".")
-
+Pkg.instantiate()
 import PackageCompiler 
 
 target = if !(length(ARGS) == 0) lowercase(ARGS[1]) else "local" end


### PR DESCRIPTION
Added `Pkg.instantiate()` to `install.jl`. After this fix, `install.jl` and then sysimage worked as expected.