### PR TITLE
Use `askem-julia` 5.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV JULIA_DEPOT_PATH=/usr/local/julia
 ENV JULIA_PROJECT=/home/jupyter/.julia/environments/askem
 
 COPY --chown=1000:1000 --from=JULIA_BASE_IMAGE /usr/local/julia /usr/local/julia
-COPY --chown=1000:1000 --from=JULIA_BASE_IMAGE /ASKEM-Sysimage.so /Project.toml /Manifest.toml /home/jupyter/.julia/environments/askem/
+COPY --chown=1000:1000 --from=JULIA_BASE_IMAGE /Project.toml /Manifest.toml /home/jupyter/.julia/environments/askem/
 RUN chmod -R 777 /usr/local/julia/logs
 RUN ln -sf /usr/local/julia/bin/julia /usr/local/bin/julia
 
@@ -46,6 +46,6 @@ WORKDIR /home/jupyter
 
 
 # Install Julia kernel (as user jupyter)
-RUN /usr/local/julia/bin/julia -J /home/jupyter/.julia/environments/askem/ASKEM-Sysimage.so -e 'using IJulia; IJulia.installkernel("julia"; julia=`/usr/local/julia/bin/julia -J /home/jupyter/.julia/environments/askem/ASKEM-Sysimage.so --threads=4`)'
+RUN /usr/local/julia/bin/julia -e 'using IJulia; IJulia.installkernel("julia"; julia=`/usr/local/julia/bin/julia --threads=4`)'
 
 CMD ["python", "-m", "beaker_kernel.server.main", "--ip", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/darpa-askem/askem-julia:3.0.0 AS JULIA_BASE_IMAGE
+FROM ghcr.io/darpa-askem/askem-julia:5.0.0 AS JULIA_BASE_IMAGE
 
 FROM python:3.10
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL=/bin/bash
+SHELL=/usr/bin/env bash
 BASEDIR = $(shell pwd)
 
 .PHONY:build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "beaker-kernel>=1.2.7",
+  "beaker-kernel @ git+https://github.com/jataware/beaker-kernel@julia-v1.10", #>=1.2.7",
   "pandas==1.3.3",
   "matplotlib~=3.7.1",
   "xarray==0.19.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "beaker-kernel @ git+https://github.com/jataware/beaker-kernel@julia-v1.10", #>=1.2.7",
+  "beaker-kernel>=1.2.10",
   "pandas==1.3.3",
   "matplotlib~=3.7.1",
   "xarray==0.19.0",

--- a/src/askem_beaker/contexts/decapodes/agent.py
+++ b/src/askem_beaker/contexts/decapodes/agent.py
@@ -55,7 +55,7 @@ No addtional text is needed in the response, just the code block.
         result = json.dumps(
             {
                 "action": "code_cell",
-                "language": "julia-1.9",
+                "language": "julia-1.10",
                 "content": code.strip(),
             }
         )

--- a/src/askem_beaker/contexts/decapodes/agent.py
+++ b/src/askem_beaker/contexts/decapodes/agent.py
@@ -55,7 +55,7 @@ No addtional text is needed in the response, just the code block.
         result = json.dumps(
             {
                 "action": "code_cell",
-                "language": "julia-1.10",
+                "language": self.context.subkernel.KERNEL_NAME,
                 "content": code.strip(),
             }
         )

--- a/src/askem_beaker/contexts/oceananigans/agent.py
+++ b/src/askem_beaker/contexts/oceananigans/agent.py
@@ -70,7 +70,7 @@ No addtional text is needed in the response, just the code block.
         result = json.dumps(
             {
                 "action": "code_cell",
-                "language": "julia-1.9",
+                "language": "julia-1.10",
                 "content": code.strip(),
             }
         )

--- a/src/askem_beaker/contexts/oceananigans/agent.py
+++ b/src/askem_beaker/contexts/oceananigans/agent.py
@@ -70,7 +70,7 @@ No addtional text is needed in the response, just the code block.
         result = json.dumps(
             {
                 "action": "code_cell",
-                "language": "julia-1.10",
+                "language": self.context.subkernel.KERNEL_NAME,
                 "content": code.strip(),
             }
         )


### PR DESCRIPTION
This PR upgrades the version of `askem-julia` being used to 5.0.0. `using` statements will be a bit slower because we got rid of the sysimage but it should only take a max of 5 seconds for Decapodes and Oceananigans (which sometimes took over a minute or two to load without sysimage in previous versions). This will break the current Decapodes context which was severely out of date anyway. Fixes to contexts will be applied as needed.


Running a Decapodes example in an `askem-beaker` notebook
![image](https://github.com/DARPA-ASKEM/beaker-kernel/assets/14170067/16f9d429-4b48-45c7-ac37-2da4ddc1870a)


## Before Merging this PR
- [ ] [Merge this other upstream PR](https://github.com/jataware/beaker-kernel/pull/14)
- [ ] Switch this PR from using `beaker-kernel` from GitHub and use PyPi instead
