### PR TITLE
Mira Model Edit expression hardening

### DIFF
--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_conversion_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_conversion_template.py
@@ -18,7 +18,7 @@ model = model.add_template(
         subject = subject_concept,
         outcome = outcome_concept,
         controller = controller_concept,
-        rate_law = sympy.parsing.sympy_parser.parse_expr("{{ template_expression }}"),
+        rate_law = sympy.parsing.sympy_parser.parse_expr("{{ template_expression }}", local_dict=_clash),
         name = "{{ template_name }}"
     ),
     parameter_mapping = parameters,

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_degradation_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_degradation_template.py
@@ -15,7 +15,7 @@ model = model.add_template(
     template = ControlledDegradation(
         subject = subject_concept,
         controller = controller_concept,
-        rate_law = sympy.parsing.sympy_parser.parse_expr("{{ template_expression }}"),
+        rate_law = sympy.parsing.sympy_parser.parse_expr("{{ template_expression }}", local_dict=_clash),
         name = "{{ template_name }}"
     ),
     parameter_mapping = parameters,

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_production_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_production_template.py
@@ -15,7 +15,7 @@ model = model.add_template(
     template = ControlledProduction(
         outcome = outcome_concept,
         controller = controller_concept,
-        rate_law = sympy.parsing.sympy_parser.parse_expr("{{ template_expression }}"),
+        rate_law = sympy.parsing.sympy_parser.parse_expr("{{ template_expression }}", local_dict=_clash),
         name = "{{ template_name }}"
     ),
     parameter_mapping = parameters,

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_conversion_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_conversion_template.py
@@ -15,7 +15,7 @@ model = model.add_template(
     template = NaturalConversion(
         subject = subject_concept,
         outcome = outcome_concept,
-        rate_law = sympy.parsing.sympy_parser.parse_expr("{{ template_expression }}"),
+        rate_law = sympy.parsing.sympy_parser.parse_expr("{{ template_expression }}", local_dict=_clash),
         name = "{{ template_name }}"
     ),
     parameter_mapping = parameters,

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_degradation_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_degradation_template.py
@@ -12,7 +12,7 @@ initials = {
 model = model.add_template(
     template = NaturalDegradation(
         subject = subject_concept,
-        rate_law = sympy.parsing.sympy_parser.parse_expr("{{ template_expression }}"),
+        rate_law = sympy.parsing.sympy_parser.parse_expr("{{ template_expression }}", local_dict=_clash),
         name = "{{ template_name }}"
     ),
     parameter_mapping = parameters,

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_production_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_production_template.py
@@ -12,7 +12,7 @@ initials = {
 model = model.add_template(
     template = NaturalProduction(
         outcome = outcome_concept,
-        rate_law = sympy.parsing.sympy_parser.parse_expr("{{ template_expression }}"),
+        rate_law = sympy.parsing.sympy_parser.parse_expr("{{ template_expression }}", local_dict=_clash),
         name = "{{ template_name }}"
     ),
     parameter_mapping = parameters,

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_observable.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_observable.py
@@ -21,7 +21,7 @@ def add_observable(model, new_id: str, new_name: str, new_expression: str):
     tm = model
     # Note that if an observable already exists with the given
     # key, it will be replaced
-    rate_law_sympy = mathml_to_expression(new_expression)
+    rate_law_sympy = sympy.parsing.sympy_parser.parse_expr(new_expression)
     new_observable = Observable(name=new_id, display_name=new_name,
                                 expression=rate_law_sympy)
     tm.observables[new_id] = new_observable

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_observable.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_observable.py
@@ -21,7 +21,7 @@ def add_observable(model, new_id: str, new_name: str, new_expression: str):
     tm = model
     # Note that if an observable already exists with the given
     # key, it will be replaced
-    rate_law_sympy = sympy.parsing.sympy_parser.parse_expr(new_expression)
+    rate_law_sympy = sympy.parsing.sympy_parser.parse_expr(new_expression, local_dict=_clash)
     new_observable = Observable(name=new_id, display_name=new_name,
                                 expression=rate_law_sympy)
     tm.observables[new_id] = new_observable

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/setup.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/setup.py
@@ -5,3 +5,4 @@ from mira.sources.amr import model_from_json; from mira.modeling.viz import Grap
 from mira.metamodel.template_model import Parameter, Distribution , Observable, \
     Initial, Concept, TemplateModel
 from mira.metamodel.io import mathml_to_expression
+from sympy.abc import _clash1, _clash2, _clash


### PR DESCRIPTION
### Description:
Expressions were failing when a S was provided in the expression. This is because its predefined as a SingletonRegistry
Using clash here will override this SingletonRegistry

### Testing: 

```
def add_observable(model, new_id: str, new_name: str, new_expression: str):
    """Add a new observable object to the template model

    Parameters
    ----------
    model : JSON
        The model as an AMR JSON
    new_id :
        The ID of the new observable to add
    new_name :
        The display name of the new observable to add
    new_expression :
        The expression of the new observable to add as a MathML XML string

    Returns
    -------
    : JSON
        The updated model as an AMR JSON
    """
    assert isinstance(model, TemplateModel)
    tm = model
    # Note that if an observable already exists with the given
    # key, it will be replaced
    rate_law_sympy = sympy.parsing.sympy_parser.parse_expr(new_expression)
    new_observable = Observable(name=new_id, display_name=new_name,
                                expression=rate_law_sympy)
    tm.observables[new_id] = new_observable
    return tm

model = add_observable(
    model, 
    "sample", 
    "sample", 
    "S + R"
)
```