### PR TITLE
Mira model Edit check for existing

### DIFF
--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_conversion_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_conversion_template.py
@@ -14,11 +14,13 @@ if "{{controller_name}}" not in concepts_name_map:
 else:
     controller_concept = concepts_name_map.get("{{controller_name}}")
 
-parameter_unit = Unit(expression = sympy.Symbol("{{ parameter_units}}"))
-
-parameters = {
-    "{{ parameter_name}}": Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, units = parameter_unit, description = "{{ parameter_description}}")
-}
+if "{{ parameter_name}}" not in model.parameters: #note this is checks for paremeter's symbol
+    parameter_unit = Unit(expression = sympy.Symbol("{{ parameter_units}}"))
+    parameters = {
+        "{{ parameter_name}}": Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, units = parameter_unit, description = "{{ parameter_description}}")
+    }
+else: 
+    parameters = {"{{ parameter_name}}": model.parameters.get("{{ parameter_name}}")}
 
 initials = { 
     "{{subject_name}}": Initial(concept = subject_concept, expression = sympy.Float({{subject_initial_value}})),

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_degradation_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_degradation_template.py
@@ -9,12 +9,13 @@ if "{{controller_name}}" not in concepts_name_map:
 else:
     controller_concept = concepts_name_map.get("{{controller_name}}")
 
-
-parameter_unit = Unit(expression = sympy.Symbol("{{ parameter_units }}"))
-
-parameters = {
-    "{{ parameter_name }}": Parameter(name = "{{ parameter_name }}", value = {{ parameter_value }}, units = parameter_unit, description = "{{ parameter_description }}")
-}
+if "{{ parameter_name}}" not in model.parameters: #note this is checks for paremeter's symbol
+    parameter_unit = Unit(expression = sympy.Symbol("{{ parameter_units}}"))
+    parameters = {
+        "{{ parameter_name}}": Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, units = parameter_unit, description = "{{ parameter_description}}")
+    }
+else: 
+    parameters = {"{{ parameter_name}}": model.parameters.get("{{ parameter_name}}")}
 
 initials = { 
     "{{subject_name }}": Initial(concept = subject_concept, expression = sympy.Float({{subject_initial_value }})),

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_production_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_production_template.py
@@ -9,12 +9,13 @@ if "{{controller_name}}" not in concepts_name_map:
 else:
     controller_concept = concepts_name_map.get("{{controller_name}}")
 
-
-parameter_unit = Unit(expression = sympy.Symbol("{{ parameter_units }}"))
-
-parameters = {
-    "{{ parameter_name }}": Parameter(name = "{{ parameter_name }}", value = {{ parameter_value }}, units = parameter_unit, description = "{{ parameter_description }}")
-}
+if "{{ parameter_name}}" not in model.parameters: #note this is checks for paremeter's symbol
+    parameter_unit = Unit(expression = sympy.Symbol("{{ parameter_units}}"))
+    parameters = {
+        "{{ parameter_name}}": Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, units = parameter_unit, description = "{{ parameter_description}}")
+    }
+else: 
+    parameters = {"{{ parameter_name}}": model.parameters.get("{{ parameter_name}}")}
 
 initials = { 
     "{{outcome_name}}": Initial(concept = outcome_concept, expression = sympy.Float({{outcome_initial_value }})),

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_conversion_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_conversion_template.py
@@ -9,11 +9,13 @@ if "{{ outcome_name }}" not in concepts_name_map:
 else:
     outcome_concept = concepts_name_map.get("{{ outcome_name }}")
 
-parameter_unit = Unit(expression = sympy.Symbol("{{ parameter_units }}"))
-
-parameters = {
-    "{{ parameter_name }}": Parameter(name = "{{ parameter_name }}", value = {{ parameter_value }}, units = parameter_unit, description = "{{ parameter_description }}")
-}
+if "{{ parameter_name}}" not in model.parameters: #note this is checks for paremeter's symbol
+    parameter_unit = Unit(expression = sympy.Symbol("{{ parameter_units}}"))
+    parameters = {
+        "{{ parameter_name}}": Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, units = parameter_unit, description = "{{ parameter_description}}")
+    }
+else: 
+    parameters = {"{{ parameter_name}}": model.parameters.get("{{ parameter_name}}")}
 
 initials = { 
     "{{subject_name }}": Initial(concept = subject_concept, expression = sympy.Float({{subject_initial_value }})),

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_degradation_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_degradation_template.py
@@ -4,11 +4,13 @@ if "{{ subject_name }}" not in concepts_name_map:
 else:
     subject_concept = concepts_name_map.get("{{ subject_name }}")
 
-parameter_unit = Unit(expression = sympy.Symbol("{{ parameter_units}}"))
-
-parameters = {
-    "{{ parameter_name }}": Parameter(name = "{{ parameter_name }}", value = {{ parameter_value }}, units = parameter_unit, description = "{{ parameter_description }}")
-}
+if "{{ parameter_name}}" not in model.parameters: #note this is checks for paremeter's symbol
+    parameter_unit = Unit(expression = sympy.Symbol("{{ parameter_units}}"))
+    parameters = {
+        "{{ parameter_name}}": Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, units = parameter_unit, description = "{{ parameter_description}}")
+    }
+else: 
+    parameters = {"{{ parameter_name}}": model.parameters.get("{{ parameter_name}}")}
 
 initials = { 
     "{{subject_name }}": Initial(concept = subject_concept, expression = sympy.Float({{subject_initial_value }}))

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_production_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_production_template.py
@@ -4,11 +4,13 @@ if "{{ outcome_name }}" not in concepts_name_map:
 else:
     outcome_concept = concepts_name_map.get("{{ outcome_name }}")
 
-parameter_unit = Unit(expression = sympy.Symbol("{{ parameter_units }}"))
-
-parameters = {
-    "{{ parameter_name }}": Parameter(name = "{{ parameter_name }}", value = {{ parameter_value }}, units = parameter_unit, description = "{{ parameter_description }}")
-}
+if "{{ parameter_name}}" not in model.parameters: #note this is checks for paremeter's symbol
+    parameter_unit = Unit(expression = sympy.Symbol("{{ parameter_units}}"))
+    parameters = {
+        "{{ parameter_name}}": Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, units = parameter_unit, description = "{{ parameter_description}}")
+    }
+else: 
+    parameters = {"{{ parameter_name}}": model.parameters.get("{{ parameter_name}}")}
 
 initials = { 
     "{{outcome_name }}": Initial(concept = outcome_concept, expression = sympy.Float({{outcome_initial_value }}))


### PR DESCRIPTION
When a user asks for a parameter that exists, do not create a new parameter but instead use the parameter in the model that exists.
There are probably cleaner approaches to this but a working solution is okay for now i think

Sample using a basic SIR with parameter: 
`"name='beta' display_name='β' description='infection rate' identifiers={} context={} units=None value=2.7e-07 distribution=Distribution(type='Uniform1', parameters={'minimum': 2.6e-07, 'maximum': 2.8e-07})"`

Question:
`Add a new transition from S to R with the name vaccine with the rate of beta.`
Result:
```
concepts_name_map = model.get_concepts_name_map()
if "S" not in concepts_name_map:
    subject_concept = Concept(name = "S")
else:
    subject_concept = concepts_name_map.get("S")

if "R" not in concepts_name_map:
    outcome_concept = Concept(name = "R")
else:
    outcome_concept = concepts_name_map.get("R")

if "beta" not in model.parameters: #note this is checks for paremeter's symbol
    parameter_unit = Unit(expression = sympy.Symbol(""))
    parameters = {
        "beta": Parameter(name = "beta", value = 1, units = parameter_unit, description = "")
    }
else: 
    parameters = {"beta": model.parameters.get("beta")}

initials = { 
    "S": Initial(concept = subject_concept, expression = sympy.Float(1)),
    "R": Initial(concept = outcome_concept, expression = sympy.Float(1))
}

model = model.add_template(
    template = NaturalConversion(
        subject = subject_concept,
        outcome = outcome_concept,
        rate_law = sympy.parsing.sympy_parser.parse_expr("beta", local_dict=_clash),
        name = "vaccine"
    ),
    parameter_mapping = parameters,
    initial_mapping = initials
)
```
