### PR TITLE
Add post execution hook with preview

### DIFF
--- a/src/askem_beaker/contexts/mira_config_edit/context.py
+++ b/src/askem_beaker/contexts/mira_config_edit/context.py
@@ -85,7 +85,7 @@ class MiraConfigEditContext(BaseContext):
         self, server=None, target_stream=None, data=None, parent_header={}
     ):
         try:
-            preview = await self.evaluate(self.get_code("model_preview"), {"var_name": self.var_name})
+            preview = await self.evaluate(self.get_code("model_preview"), {"var_name": self.var_name, "schema_name": self.schema_name})
             content = preview["return"]
             self.beaker_kernel.send_response(
                 "iopub", "model_preview", content, parent_header=parent_header

--- a/src/askem_beaker/contexts/mira_config_edit/context.py
+++ b/src/askem_beaker/contexts/mira_config_edit/context.py
@@ -36,9 +36,6 @@ class MiraConfigEditContext(BaseContext):
 
     def reset(self):
         pass
-
-    async def post_execute(self, message):
-        pass    
         
     async def setup(self, config, parent_header):
         logger.error(f"performing setup...")
@@ -49,6 +46,9 @@ class MiraConfigEditContext(BaseContext):
         await self.set_model_config(
             item_id, item_type, parent_header=parent_header
         )
+
+    async def post_execute(self, message):
+        await self.send_mira_preview_message(parent_header=message.parent_header)
 
     async def set_model_config(self, item_id, agent=None, parent_header={}):
         self.config_id = item_id
@@ -85,7 +85,6 @@ class MiraConfigEditContext(BaseContext):
         self, server=None, target_stream=None, data=None, parent_header={}
     ):
         try:
-
             preview = await self.evaluate(self.get_code("model_preview"), {"var_name": self.var_name})
             content = preview["return"]
             self.beaker_kernel.send_response(

--- a/src/askem_beaker/contexts/mira_config_edit/procedures/python3/model_preview.py
+++ b/src/askem_beaker/contexts/mira_config_edit/procedures/python3/model_preview.py
@@ -1,10 +1,20 @@
 from IPython.core.interactiveshell import InteractiveShell;
 from IPython.core import display_functions;
 from mira.modeling.amr.petrinet import template_model_to_petrinet_json
+from mira.modeling.amr.stockflow import template_model_to_stockflow_json;
+from mira.modeling.amr.regnet import template_model_to_regnet_json;
 
-format_dict, md_dict = InteractiveShell.instance().display_formatter.format(GraphicalModel.for_jupyter(model_config))
+format_dict, md_dict = InteractiveShell.instance().display_formatter.format(GraphicalModel.for_jupyter({{ var_name|default("model_config") }}))
+
+if "{{ schema_name }}" == "regnet":
+    model_json = template_model_to_regnet_json({{ var_name|default("model_config") }})
+elif "{{ schema_name }}" == "stockflow":
+    model_json = template_model_to_stockflow_json({{ var_name|default("model_config") }})
+else:
+    model_json = template_model_to_petrinet_json({{ var_name|default("model_config") }})
+
 result = {
-    "application/json": template_model_to_petrinet_json(model_config)
+    "application/json": model_json
 }
 for key, value in format_dict.items():
     if "image" in key:

--- a/src/askem_beaker/contexts/mira_model/context.py
+++ b/src/askem_beaker/contexts/mira_model/context.py
@@ -125,7 +125,7 @@ If you are asked to manipulate, stratify, or visualize the model, use the genera
     ):
         try:
 
-            preview = await self.evaluate(self.get_code("model_preview"), {"var_name": self.var_name})
+            preview = await self.evaluate(self.get_code("model_preview"), {"var_name": self.var_name, "schema_name": self.schema_name})
             content = preview["return"]
             self.beaker_kernel.send_response(
                 "iopub", "model_preview", content, parent_header=parent_header

--- a/src/askem_beaker/contexts/mira_model/procedures/python3/model_preview.py
+++ b/src/askem_beaker/contexts/mira_model/procedures/python3/model_preview.py
@@ -1,11 +1,20 @@
 from IPython.core.interactiveshell import InteractiveShell;
 from IPython.core import display_functions;
 from mira.modeling.amr.petrinet import template_model_to_petrinet_json
-from mira.modeling.viz import GraphicalModel;
+from mira.modeling.amr.stockflow import template_model_to_stockflow_json;
+from mira.modeling.amr.regnet import template_model_to_regnet_json;
 
-format_dict, md_dict = InteractiveShell.instance().display_formatter.format(GraphicalModel.for_jupyter(model))
+format_dict, md_dict = InteractiveShell.instance().display_formatter.format(GraphicalModel.for_jupyter({{ var_name|default("model") }}))
+
+if "{{ schema_name }}" == "regnet":
+    model_json = template_model_to_regnet_json({{ var_name|default("model") }})
+elif "{{ schema_name }}" == "stockflow":
+    model_json = template_model_to_stockflow_json({{ var_name|default("model") }})
+else:
+    model_json = template_model_to_petrinet_json({{ var_name|default("model") }})
+
 result = {
-    "application/json": template_model_to_petrinet_json(model)
+    "application/json": model_json
 }
 for key, value in format_dict.items():
     if "image" in key:


### PR DESCRIPTION
Simple PR to add the post execution hook with the `model` response (not the full configuration wrapper) in the `mira_config_edit` context.

This also ensure support for previews of regnet + stock and flow on both the `mira_config_edit` context as well as the `mira_model` context.