### PR TITLE
Clear dataset columns when creating a new dataset

### DIFF
--- a/src/askem_beaker/contexts/dataset/context.py
+++ b/src/askem_beaker/contexts/dataset/context.py
@@ -236,6 +236,8 @@ Statistics:
         new_dataset["name"] = new_name
         new_dataset["description"] += f"\\nTransformed from dataset '{parent_dataset['name']}' ({parent_dataset['id']}) at {datetime.datetime.utcnow().strftime('%c %Z')}"
         new_dataset["fileNames"] = [filename]
+        #clear the columns field on the new dataset as there was likely a change to either the columns or the data. HMI-Server will deal with regenerating this.
+        new_dataset["columns"] = []
 
         import pprint
         logger.error(f"new dataset: {pprint.pformat(new_dataset)}")


### PR DESCRIPTION
If a user is saving a modified dataset there is a likelyhood that columns and/or data have changed, so the HMI-Server needs a clue that the columns information should be reset.