### PR TITLE
Add cartopy to pyproject and bump askem-julia version in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/darpa-askem/askem-julia:7.0.0 AS JULIA_BASE_IMAGE
+FROM ghcr.io/darpa-askem/askem-julia:7.0.1 AS JULIA_BASE_IMAGE
 
 FROM python:3.10
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ dependencies = [
   "netcdf4==1.6.5",
   "cftime==1.6.3",
   "flowcast==0.3.3",
-  "basemap==1.4.1"
+  "basemap==1.4.1",
+  "cartopy~=0.22.0",
 ]
 
 [tool.hatch.metadata]


### PR DESCRIPTION
This PR adds Cartopy to the environment so it can be used for visualization and also bumps the `askem-julia` version to `7.0.1` (@fivegrant I know that's also covered in your `optimize` PR but figured I can add it here as well otherwise the build fails for me)

In this screenshot you can see that Cartopy was installed successfully.

![Screenshot 2024-03-13 at 2 19 54 PM](https://github.com/DARPA-ASKEM/beaker-kernel/assets/5840199/75e08881-dfcc-4a80-baaa-8ca076fcf270)
