### PR TITLE
mira and mira_model contexts: save_amr message 

### DIFF
--- a/docs/contexts_mira.md
+++ b/docs/contexts_mira.md
@@ -28,6 +28,32 @@ This context is used for new development around [Mira](https://github.com/gyoril
     ]
 }
 ```
+## Custom Actions  
+### `save_amr`
+
+Message Payload:  
+* `name`: string, name of the new model to save
+* `model_var`: string, name of the variable containing a mira model; can be a newly created one or any of the ones loaded in context setup
+* `project_id`: *optional*, will save the model to the given project if desired.
+
+#### Save a new model to a given project:
+```
+{
+  "name": "New SIR model with changes",
+  "model_var": "sir_model",
+  "project_id": "d59c00f3-aeb9-42ed-97bf-cc36c14cd008"
+}
+```
+
+#### Save a new model to no specific project:
+```
+{
+  "name": "New SIR model with changes",
+  "model_var": "sir_model",
+}
+```
+
+## Interactive Use
 
 > **Note**: after setup, the models are accessible via the variable names corresponding to the given `name` field.
 

--- a/docs/contexts_mira_model.md
+++ b/docs/contexts_mira_model.md
@@ -20,9 +20,11 @@ This context is used for editing models via [Mira](https://github.com/gyorilab/m
 
 This context's LLM agent supports generic code generation using Mira with a specific focus on stratification. Users have the ability to ask to perform a stratification (e.g. _"Stratify my model into two cities: Boston and New York"_).
 
+This context has 
+
 This context has **4 custom message types**:
 
-1. `save_amr_request`: takes in a `name` and saves the model as a new model in `hmi-server`, returning the new models `id`
+1. `save_amr_request`: takes in a `name` and saves the model as a new model in `hmi-server`, returning the new models `id`. Optionally takes in a `project_id` to save the model into the project.
 2. `amr_to_templates`: converts AMR in JSON format to a Mira Template Model. Optionally accepts `model_name` which defaults to `model`--the variable where the AMR JSON is stored in context
 3. `stratify_request`: stratifies the model based on `stratify_args` provided. Optionally accepts `model_name` which defaults to `model`--the variable where the AMR JSON is stored in context
 4. `reset_request`: resets the `model` back to its original state

--- a/src/askem_beaker/contexts/mira/context.py
+++ b/src/askem_beaker/contexts/mira/context.py
@@ -135,25 +135,17 @@ class Context(BaseContext):
                 "description"
             ] += f"\nTransformed from model '{original_name}' ({original_model_id}) at {datetime.datetime.utcnow().strftime('%c %Z')}"
 
-        if project_id is None:
-            create_req = requests.post(
-                f"{os.environ['HMI_SERVER_URL']}/models",
-                json=new_model,
-                auth=self.auth_details,
-            )
-            new_model_id = create_req.json()["id"]
+        create_req = requests.post(
+            f"{os.environ['HMI_SERVER_URL']}/models",
+            json=new_model,
+            auth=self.auth_details,
+        )
+        if create_req.status_code >= 300:
+            msg = f"failed to put new model: {create_req.status_code}"
+            raise ValueError(msg)
+        new_model_id = create_req.json()["id"]
 
-        else:
-            create_req = requests.post(
-                f"{os.environ['HMI_SERVER_URL']}/models",
-                json=new_model,
-                auth=self.auth_details,
-            )
-            if create_req.status_code >= 300:
-                msg = f"failed to put new model: {create_req.status_code}"
-                raise ValueError(msg)
-            new_model_id = create_req.json()["id"]
-
+        if project_id is not None:
             update_req = requests.post(
                 f"{os.environ['HMI_SERVER_URL']}/projects/{project_id}/assets/model/{new_model_id}",
                 auth=self.auth_details,

--- a/src/askem_beaker/contexts/mira/context.py
+++ b/src/askem_beaker/contexts/mira/context.py
@@ -6,9 +6,13 @@ import os
 import pickle
 from importlib import import_module
 from typing import TYPE_CHECKING, Any, Dict
+from uuid import uuid4
+import requests
+import datetime
 
 from beaker_kernel.lib.context import BaseContext
 from beaker_kernel.lib.subkernels.python import PythonSubkernel
+from beaker_kernel.lib.utils import action
 
 from .agent import Agent, CONTEXT_JSON
 
@@ -49,6 +53,7 @@ class Context(BaseContext):
                 for i in range(len(self.code_blocks))
             ]
         )
+        self.amrs = {}
 
         super().__init__(beaker_kernel, subkernel, self.agent_cls, config)
 
@@ -70,21 +75,95 @@ class Context(BaseContext):
         await self.load_mira_model(name, model_url)
 
     async def load_mira_model(self, name, model_url):
+        amr_json = requests.get(model_url, auth=self.auth_details, timeout=10).json()
+        self.amrs[name] = amr_json
         command = "\n".join(
             [
                 self.get_code("mira_setup"),
                 self.get_code(
                     "load_mira_model",
-                    {
-                        "var_name": name,
-                        "model_url": model_url,
-                        "auth_details": self.auth_details,
-                    },
+                    {"var_name": name, "amr_json": amr_json},
                 ),
             ]
         )
         print(f"Running command:\n-------\n{command}\n---------")
         await self.execute(command)
+
+    @action()
+    async def save_amr(self, message):
+        content = message.content
+
+        new_name = content.get("name")
+        model_var = content.get("model_var")
+        project_id = content.get("project_id")
+
+        schema_name = self.amrs[model_var].get("header", {}).get("schema_name", "")
+        # Deprecated: get schema name from old format if needed
+        if schema_name == "":
+            schema_name = self.amrs[model_var].get("schema_name", "")
+
+        imports = "\n".join(
+            [
+                f"from mira.modeling.amr.{t} import template_model_to_{t}_json"
+                for t in ["regnet", "stockflow", "petrinet"]
+            ]
+        )
+        if schema_name == "regnet":
+            unloader = f"{imports}\ntemplate_model_to_regnet_json({model_var})"
+        elif schema_name == "stockflow":
+            unloader = f"{imports}\ntemplate_model_to_stockflow_json({model_var})"
+        else:
+            unloader = f"{imports}\ntemplate_model_to_petrinet_json({model_var})"
+
+        new_model: dict = (await self.evaluate(unloader))["return"]
+
+        original_name = new_model.get("header", {}).get("name", "None")
+        original_model_id = self.amrs[model_var]["id"]
+
+        # Deprecated: Handling both new and old model formats
+
+        if "header" in new_model:
+            new_model["header"]["name"] = new_name
+            new_description = (
+                new_model.get("header", {}).get("description", "")
+                + f"\nTransformed from model '{original_name}' ({original_model_id}) at {datetime.datetime.utcnow().strftime('%c %Z')}"
+            )
+            new_model["header"]["description"] = new_description
+        else:
+            new_model["name"] = new_name
+            new_model[
+                "description"
+            ] += f"\nTransformed from model '{original_name}' ({original_model_id}) at {datetime.datetime.utcnow().strftime('%c %Z')}"
+
+        if project_id is None:
+            create_req = requests.post(
+                f"{os.environ['HMI_SERVER_URL']}/models",
+                json=new_model,
+                auth=self.auth_details,
+            )
+            new_model_id = create_req.json()["id"]
+
+        else:
+            create_req = requests.post(
+                f"{os.environ['HMI_SERVER_URL']}/models",
+                json=new_model,
+                auth=self.auth_details,
+            )
+            if create_req.status_code >= 300:
+                msg = f"failed to put new model: {create_req.status_code}"
+                raise ValueError(msg)
+            new_model_id = create_req.json()["id"]
+
+            update_req = requests.post(
+                f"{os.environ['HMI_SERVER_URL']}/projects/{project_id}/assets/model/{new_model_id}",
+                auth=self.auth_details,
+            )
+            if update_req.status_code >= 300:
+                msg = f"failed to add to project id {project_id}: {new_model_id}: {update_req.status_code}"
+                raise ValueError(msg)
+
+        content = {"model_id": new_model_id}
+        self.beaker_kernel.send_response("iopub", "save_amr_response", content, parent_header=message.header)
 
     async def get_jupyter_context(self):
         imported_modules = []

--- a/src/askem_beaker/contexts/mira/procedures/python3/load_mira_model.py
+++ b/src/askem_beaker/contexts/mira/procedures/python3/load_mira_model.py
@@ -1,5 +1,5 @@
-import copy, requests
+import copy
 from mira.sources.amr import model_from_json
-amr_json = requests.get("{{ model_url }}", auth={{auth_details}}, timeout=10).json()
+amr_json = {{amr_json}}
 {{ var_name|default("model") }} = model_from_json(amr_json)
 _{{ var_name|default("model") }}_orig = copy.deepcopy({{ var_name|default("model") }})

--- a/src/askem_beaker/contexts/mira_model/context.py
+++ b/src/askem_beaker/contexts/mira_model/context.py
@@ -139,6 +139,7 @@ If you are asked to manipulate, stratify, or visualize the model, use the genera
         content = message.content
 
         new_name = content.get("name")
+        project_id = content.get("project_id")
 
         if self.schema_name == "regnet":
             unloader = f"template_model_to_regnet_json({self.var_name})"
@@ -179,6 +180,12 @@ If you are asked to manipulate, stratify, or visualize the model, use the genera
             auth=self.auth.requests_auth(),
         )
         new_model_id = create_req.json()["id"]
+
+        if project_id is not None:
+            update_req = requests.post(
+                f"{os.environ['HMI_SERVER_URL']}/projects/{project_id}/assets/model/{new_model_id}",
+                auth=self.auth.requests_auth(),
+            )
 
         content = {"model_id": new_model_id}
         self.beaker_kernel.send_response(


### PR DESCRIPTION
Adds `project_id` to the `save_amr` (mira context) and `save_amr_request` (mira_model context) messages which will handle the specified save directly into the project. Also adds `save_amr` to mira context and documents the new message and expected arguments.