### PR TITLE
move to MIRA's safe parse

### DIFF
--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_conversion_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_conversion_template.py
@@ -33,7 +33,7 @@ model = model.add_template(
         subject = subject_concept,
         outcome = outcome_concept,
         controller = controller_concept,
-        rate_law = sympy.parsing.sympy_parser.parse_expr("{{ template_expression }}", local_dict=_clash),
+        rate_law = safe_parse_expr("{{ template_expression }}", local_dict=_clash),
         name = "{{ template_name }}"
     ),
     parameter_mapping = parameters,

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_degradation_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_degradation_template.py
@@ -26,7 +26,7 @@ model = model.add_template(
     template = ControlledDegradation(
         subject = subject_concept,
         controller = controller_concept,
-        rate_law = sympy.parsing.sympy_parser.parse_expr("{{ template_expression }}", local_dict=_clash),
+        rate_law = safe_parse_expr("{{ template_expression }}", local_dict=_clash),
         name = "{{ template_name }}"
     ),
     parameter_mapping = parameters,

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_production_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_production_template.py
@@ -26,7 +26,7 @@ model = model.add_template(
     template = ControlledProduction(
         outcome = outcome_concept,
         controller = controller_concept,
-        rate_law = sympy.parsing.sympy_parser.parse_expr("{{ template_expression }}", local_dict=_clash),
+        rate_law = safe_parse_expr("{{ template_expression }}", local_dict=_clash),
         name = "{{ template_name }}"
     ),
     parameter_mapping = parameters,

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_conversion_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_conversion_template.py
@@ -26,7 +26,7 @@ model = model.add_template(
     template = NaturalConversion(
         subject = subject_concept,
         outcome = outcome_concept,
-        rate_law = sympy.parsing.sympy_parser.parse_expr("{{ template_expression }}", local_dict=_clash),
+        rate_law = safe_parse_expr("{{ template_expression }}", local_dict=_clash),
         name = "{{ template_name }}"
     ),
     parameter_mapping = parameters,

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_degradation_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_degradation_template.py
@@ -19,7 +19,7 @@ initials = {
 model = model.add_template(
     template = NaturalDegradation(
         subject = subject_concept,
-        rate_law = sympy.parsing.sympy_parser.parse_expr("{{ template_expression }}", local_dict=_clash),
+        rate_law = safe_parse_expr("{{ template_expression }}", local_dict=_clash),
         name = "{{ template_name }}"
     ),
     parameter_mapping = parameters,

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_production_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_production_template.py
@@ -19,7 +19,7 @@ initials = {
 model = model.add_template(
     template = NaturalProduction(
         outcome = outcome_concept,
-        rate_law = sympy.parsing.sympy_parser.parse_expr("{{ template_expression }}", local_dict=_clash),
+        rate_law = safe_parse_expr("{{ template_expression }}", local_dict=_clash),
         name = "{{ template_name }}"
     ),
     parameter_mapping = parameters,

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_observable.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_observable.py
@@ -21,7 +21,7 @@ def add_observable(model, new_id: str, new_name: str, new_expression: str):
     tm = model
     # Note that if an observable already exists with the given
     # key, it will be replaced
-    rate_law_sympy = sympy.parsing.sympy_parser.parse_expr(new_expression, local_dict=_clash)
+    rate_law_sympy = safe_parse_expr(new_expression, local_dict=_clash)
     new_observable = Observable(name=new_id, display_name=new_name,
                                 expression=rate_law_sympy)
     tm.observables[new_id] = new_observable


### PR DESCRIPTION
Ben suggested we move to his parser as its a wrapper that adds a bit of safety around things such as "lamda"