### PR TITLE
Moving stratify procedure to model edit

### DIFF
--- a/src/askem_beaker/contexts/mira_model_edit/agent.py
+++ b/src/askem_beaker/contexts/mira_model_edit/agent.py
@@ -480,15 +480,21 @@ class MiraModelEditAgent(BaseAgent):
                 These will be the individual groups used to stratify by. This should be converted to a list of strings for e.g., ``["boston", "nyc"]``
                 or ``["geonames:4930956", "geonames:5128581"]``.
             structure (Optional):
+                This describes how different strata within the same state are able to interact.
                 An iterable of pairs corresponding to a directed network structure
                 where each of the pairs has two strata. If none given, will assume a complete
-                network structure. If no structure is necessary, pass an empty list. If the schema_name is 'regnet'
-                you must ALWAYS pass an empty list to this argument.
+                network structure. If no structure is necessary, pass an empty list. 
+                By default this should be an empty list. 
             directed (bool):
-                Should the reverse direction conversions be added based on the given structure?
+                If the structure tuples are combinations this should be True. If they are permutations this should be false.
                 If this value cannot be found it should default to False
             cartesian_control (bool):
-                If true, splits all control relationships based on the stratification.
+                True if the strata from different state variables can interact. 
+                For example Susceptible young people can interact with infected old poeple.
+                false if they cannot interact.
+                For example the infected people in Toronto do not interact with the susceptible people in Boston
+                
+                This will split all control relationships based on the stratification.
 
                 This should be true for an SIR epidemiology model, the susceptibility to
                 infected transition is controlled by infected. If the model is stratified by

--- a/src/askem_beaker/contexts/mira_model_edit/agent.py
+++ b/src/askem_beaker/contexts/mira_model_edit/agent.py
@@ -494,12 +494,12 @@ class MiraModelEditAgent(BaseAgent):
     ):
         """
         This tool is used when a user wants to stratify a model. 
-        This will multiple the model into several strata.
+        This will multiple the model utilizing several strata.
 
         An example of this would be "Stratify by location Toronto, Ottawa and Montreal. There are no interactions between members unless they are in the same location."
         Here we can see that the key is location.
         We can also see that the strata groups are Toronto, Ottawa and Montreal so we will write this as ["Toronto", "Ottawa", "Montreal"].
-        The last sentence here informs us that caertesian_control is True, directed is False, and structure can be left as []
+        The last sentence here informs us that cartesian_control is True, directed is False, and structure can be left as []
 
         Args:
             key (str):

--- a/src/askem_beaker/contexts/mira_model_edit/context.py
+++ b/src/askem_beaker/contexts/mira_model_edit/context.py
@@ -539,3 +539,34 @@ class MiraModelEditContext(BaseContext):
 		self.beaker_kernel.send_response(
 			"iopub", "amr_to_templates_response", content, parent_header=message.header
 		)
+
+	@intercept()
+	async def stratify_request(self, message):
+		content = message.content
+
+		key = content.get("key"),
+		strata = content.get("strata"),
+		concepts_to_stratify = content.get("concepts_to_stratify"),
+		params_to_stratify = content.get("params_to_stratify"),
+		cartesian_control = content.get("cartesian_control"),
+		structure = content.get("structure")
+
+		stratify_code = self.get_code("stratify", {
+		    "key": key,
+		    "strata": strata,
+		    "concepts_to_stratify": concepts_to_stratify,
+		    "params_to_stratify": params_to_stratify,
+		    "cartesian_control": cartesian_control,
+		    "structure": structure
+		})
+		stratify_result = await self.execute(stratify_code)
+
+		content = {
+		    "success": True,
+		    "executed_code": stratify_result["parent"].content["code"],
+		}
+
+		self.beaker_kernel.send_response(
+		    "iopub", "stratify_response", content, parent_header=message.header
+		)
+		await self.send_mira_preview_message(parent_header=message.header)

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/stratify.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/stratify.py
@@ -1,0 +1,39 @@
+"""
+structure :
+    An iterable of pairs corresponding to a directed network structure
+    where each of the pairs has two strata. If none given, will assume a complete
+    network structure. If no structure is necessary, pass an empty list.
+
+directed :
+    Should the reverse direction conversions be added based on the given structure?
+
+cartesian_control :
+    If true, splits all control relationships based on the stratification.
+
+    This should be true for an SIR epidemiology model, the susceptibility to
+    infected transition is controlled by infected. If the model is stratified by
+    vaccinated and unvaccinated, then the transition from vaccinated
+    susceptible population to vaccinated infected populations should be
+    controlled by both infected vaccinated and infected unvaccinated
+    populations.
+
+    This should be false for stratification of an SIR epidemiology model based
+    on cities, since the infected population in one city won't (directly,
+    through the perspective of the model) affect the infection of susceptible
+    population in another city.
+
+modify_names :
+    If true, will modify the names of the concepts to include the strata
+    (e.g., ``"S"`` becomes ``"S_boston"``). If false, will keep the original
+    names.
+"""
+
+model = stratify(
+    template_model=model,
+    key= "{{ key }}",
+    strata={{ strata}},
+    structure= {{ structure|default(None) }},
+    directed={{ directed|default(False) }},
+    cartesian_control={{ cartesian_control|default(False) }},
+    modify_names={{ modify_names|default(True) }}
+)

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/stratify.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/stratify.py
@@ -5,5 +5,7 @@ model = stratify(
     structure= {{ structure|default(None) }},
     directed={{ directed|default(False) }},
     cartesian_control={{ cartesian_control|default(False) }},
-    modify_names={{ modify_names|default(True) }}
+    modify_names={{ modify_names|default(True) }},
+    concepts_to_stratify={{ concepts_to_stratify|default(None) }}, #If none given, will stratify all concepts.
+	params_to_stratify= {{ params_to_stratify|default(None) }} #If none given, will stratify all parameters.
 )

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/stratify.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/stratify.py
@@ -1,33 +1,3 @@
-"""
-structure :
-    An iterable of pairs corresponding to a directed network structure
-    where each of the pairs has two strata. If none given, will assume a complete
-    network structure. If no structure is necessary, pass an empty list.
-
-directed :
-    Should the reverse direction conversions be added based on the given structure?
-
-cartesian_control :
-    If true, splits all control relationships based on the stratification.
-
-    This should be true for an SIR epidemiology model, the susceptibility to
-    infected transition is controlled by infected. If the model is stratified by
-    vaccinated and unvaccinated, then the transition from vaccinated
-    susceptible population to vaccinated infected populations should be
-    controlled by both infected vaccinated and infected unvaccinated
-    populations.
-
-    This should be false for stratification of an SIR epidemiology model based
-    on cities, since the infected population in one city won't (directly,
-    through the perspective of the model) affect the infection of susceptible
-    population in another city.
-
-modify_names :
-    If true, will modify the names of the concepts to include the strata
-    (e.g., ``"S"`` becomes ``"S_boston"``). If false, will keep the original
-    names.
-"""
-
 model = stratify(
     template_model=model,
     key= "{{ key }}",


### PR DESCRIPTION
Add a stratify `procedure` and `tool` to the mira_model_edit context so this can be used rather than the `mira_model`'s version of this.